### PR TITLE
Catching the exception when Facebook returns error_code instead of access_key

### DIFF
--- a/ng-cordova-oauth.js
+++ b/ng-cordova-oauth.js
@@ -312,7 +312,7 @@
                                 if(parameterMap.access_token !== undefined && parameterMap.access_token !== null) {
                                     deferred.resolve({ access_token: parameterMap.access_token, expires_in: parameterMap.expires_in });
                                 } else {
-                                  if ((event.url).indexOf("error_code=100") != 0)
+                                  if ((event.url).indexOf("error_code=100") !== 0)
                                     deferred.reject("Facebook returned error_code=100: Invalid permissions");
                                   else
                                     deferred.reject("Problem authenticating");

--- a/ng-cordova-oauth.js
+++ b/ng-cordova-oauth.js
@@ -312,6 +312,9 @@
                                 if(parameterMap.access_token !== undefined && parameterMap.access_token !== null) {
                                     deferred.resolve({ access_token: parameterMap.access_token, expires_in: parameterMap.expires_in });
                                 } else {
+                                  if ((event.url).indexOf("error_code=100") != 0)
+                                    deferred.reject("Facebook returned error_code=100: Invalid permissions");
+                                  else
                                     deferred.reject("Problem authenticating");
                                 }
                             }


### PR DESCRIPTION
Catching the exception when Facebook returns error_code 100 instead of a access_key.

It happens when you try to login with invalid permission set.