### PR TITLE
Refactor to remove error check duplication DO NOT MERGE

### DIFF
--- a/ng-cordova-oauth.js
+++ b/ng-cordova-oauth.js
@@ -60,6 +60,42 @@
         };
 
         var providers = {
+          instagram: function(clientId, appScope, options) {
+            var split_tokens = {
+                'code':'?',
+                'token':'#'
+            };
+            var redirect_uri = "http://localhost/callback";
+            var response_type = "token";
+            if(options !== undefined) {
+                if(options.hasOwnProperty("redirect_uri")) {
+                    redirect_uri = options.redirect_uri;
+                }
+                if(options.hasOwnProperty("response_type")) {
+                    response_type = options.response_type;
+                }
+            }
+
+            var browserRef = window.open('https://api.instagram.com/oauth/authorize/?client_id=' + clientId + '&redirect_uri=' + redirect_uri + '&scope=' + appScope.join(" ") + '&response_type='+response_type, '_blank', 'location=no,clearsessioncache=yes,clearcache=yes');
+            browserRef.addEventListener('loadstart', function(event) {
+                if((event.url).indexOf(redirect_uri) === 0) {
+                    browserRef.removeEventListener("exit",function(event){});
+                    browserRef.close();
+                    var callbackResponse = (event.url).split(split_tokens[response_type])[1];
+                    var parameterMap = $cordovaOauthUtility.parseResponseParameters(callbackResponse);
+                    if(parameterMap.access_token !== undefined && parameterMap.access_token !== null) {
+                        deferred.resolve({ access_token: parameterMap.access_token });
+                    } else if(parameterMap.code !== undefined && parameterMap.code !== null) {
+                        deferred.resolve({ code: parameterMap.code });
+                    } else {
+                        deferred.reject("Problem authenticating");
+                    }
+                }
+            });
+            browserRef.addEventListener('exit', function(event) {
+                deferred.reject("The sign in flow was canceled");
+            });
+          },
           facebook: function(deferred, clientId, appScope, options) {
               var redirect_uri = "http://localhost/callback";
               if(options !== undefined) {
@@ -424,53 +460,7 @@
              * @return   promise
              */
             instagram: function(clientId, appScope, options) {
-                var deferred = $q.defer();
-
-                var split_tokens = {
-                    'code':'?',
-                    'token':'#'
-                };
-
-                if(window.cordova) {
-                    var cordovaMetadata = cordova.require("cordova/plugin_list").metadata;
-                    if(inAppBrowserInstalled(cordovaMetadata) === true) {
-                        var redirect_uri = "http://localhost/callback";
-                        var response_type = "token";
-                        if(options !== undefined) {
-                            if(options.hasOwnProperty("redirect_uri")) {
-                                redirect_uri = options.redirect_uri;
-                            }
-                            if(options.hasOwnProperty("response_type")) {
-                                response_type = options.response_type;
-                            }
-                        }
-
-                        var browserRef = window.open('https://api.instagram.com/oauth/authorize/?client_id=' + clientId + '&redirect_uri=' + redirect_uri + '&scope=' + appScope.join(" ") + '&response_type='+response_type, '_blank', 'location=no,clearsessioncache=yes,clearcache=yes');
-                        browserRef.addEventListener('loadstart', function(event) {
-                            if((event.url).indexOf(redirect_uri) === 0) {
-                                browserRef.removeEventListener("exit",function(event){});
-                                browserRef.close();
-                                var callbackResponse = (event.url).split(split_tokens[response_type])[1];
-                                var parameterMap = $cordovaOauthUtility.parseResponseParameters(callbackResponse);
-                                if(parameterMap.access_token !== undefined && parameterMap.access_token !== null) {
-                                    deferred.resolve({ access_token: parameterMap.access_token });
-                                } else if(parameterMap.code !== undefined && parameterMap.code !== null) {
-                                    deferred.resolve({ code: parameterMap.code });
-                                } else {
-                                    deferred.reject("Problem authenticating");
-                                }
-                            }
-                        });
-                        browserRef.addEventListener('exit', function(event) {
-                            deferred.reject("The sign in flow was canceled");
-                        });
-                    } else {
-                        deferred.reject("Could not find InAppBrowser plugin");
-                    }
-                } else {
-                    deferred.reject("Cannot authenticate via a web browser");
-                }
-                return deferred.promise;
+              return wrapWithChecks('instagram', arguments);
             },
 
             /*

--- a/ng-cordova-oauth.js
+++ b/ng-cordova-oauth.js
@@ -60,6 +60,99 @@
         };
 
         var providers = {
+          twitter: function(clientId, clientSecret, options) {
+            var redirect_uri = "http://localhost/callback";
+            if(options !== undefined) {
+                if(options.hasOwnProperty("redirect_uri")) {
+                    redirect_uri = options.redirect_uri;
+                }
+            }
+
+            if(typeof jsSHA !== "undefined") {
+                var oauthObject = {
+                    oauth_consumer_key: clientId,
+                    oauth_nonce: $cordovaOauthUtility.createNonce(10),
+                    oauth_signature_method: "HMAC-SHA1",
+                    oauth_timestamp: Math.round((new Date()).getTime() / 1000.0),
+                    oauth_version: "1.0"
+                };
+                var signatureObj = $cordovaOauthUtility.createSignature("POST", "https://api.twitter.com/oauth/request_token", oauthObject,  { oauth_callback: redirect_uri }, clientSecret);
+                $http({
+                    method: "post",
+                    url: "https://api.twitter.com/oauth/request_token",
+                    headers: {
+                        "Authorization": signatureObj.authorization_header,
+                        "Content-Type": "application/x-www-form-urlencoded"
+                    },
+                    data: "oauth_callback=" + encodeURIComponent(redirect_uri)
+                })
+                    .success(function(requestTokenResult) {
+                        var requestTokenParameters = (requestTokenResult).split("&");
+                        var parameterMap = {};
+                        for(var i = 0; i < requestTokenParameters.length; i++) {
+                            parameterMap[requestTokenParameters[i].split("=")[0]] = requestTokenParameters[i].split("=")[1];
+                        }
+                        if(parameterMap.hasOwnProperty("oauth_token") === false) {
+                            deferred.reject("Oauth request token was not received");
+                        }
+                        var browserRef = window.open('https://api.twitter.com/oauth/authenticate?oauth_token=' + parameterMap.oauth_token, '_blank', 'location=no,clearsessioncache=yes,clearcache=yes');
+                        browserRef.addEventListener('loadstart', function(event) {
+                            if((event.url).indexOf(redirect_uri) === 0) {
+                                var callbackResponse = (event.url).split("?")[1];
+                                var responseParameters = (callbackResponse).split("&");
+                                var parameterMap = {};
+                                for(var i = 0; i < responseParameters.length; i++) {
+                                    parameterMap[responseParameters[i].split("=")[0]] = responseParameters[i].split("=")[1];
+                                }
+                                if(parameterMap.hasOwnProperty("oauth_verifier") === false) {
+                                    deferred.reject("Browser authentication failed to complete.  No oauth_verifier was returned");
+                                }
+                                delete oauthObject.oauth_signature;
+                                oauthObject.oauth_token = parameterMap.oauth_token;
+                                var signatureObj = $cordovaOauthUtility.createSignature("POST", "https://api.twitter.com/oauth/access_token", oauthObject,  { oauth_verifier: parameterMap.oauth_verifier }, clientSecret);
+                                $http({
+                                    method: "post",
+                                    url: "https://api.twitter.com/oauth/access_token",
+                                    headers: {
+                                        "Authorization": signatureObj.authorization_header
+                                    },
+                                    params: {
+                                        "oauth_verifier": parameterMap.oauth_verifier
+                                    }
+                                })
+                                    .success(function(result) {
+                                        var accessTokenParameters = result.split("&");
+                                        var parameterMap = {};
+                                        for(var i = 0; i < accessTokenParameters.length; i++) {
+                                            parameterMap[accessTokenParameters[i].split("=")[0]] = accessTokenParameters[i].split("=")[1];
+                                        }
+                                        if(parameterMap.hasOwnProperty("oauth_token_secret") === false) {
+                                            deferred.reject("Oauth access token was not received");
+                                        }
+                                        deferred.resolve(parameterMap);
+                                    })
+                                    .error(function(error) {
+                                        deferred.reject(error);
+                                    })
+                                    .finally(function() {
+                                        setTimeout(function() {
+                                            browserRef.close();
+                                        }, 10);
+                                    });
+                            }
+                        });
+                        browserRef.addEventListener('exit', function(event) {
+                            deferred.reject("The sign in flow was canceled");
+                        });
+                    })
+                    .error(function(error) {
+                        deferred.reject(error);
+                    });
+                } else {
+                    deferred.reject("Missing jsSHA JavaScript library");
+                }
+
+          },
           instagram: function(clientId, appScope, options) {
             var split_tokens = {
                 'code':'?',
@@ -560,108 +653,8 @@
              * @param    string clientSecret
              * @return   promise
              */
-            twitter: function(clientId, clientSecret, options) {
-                var deferred = $q.defer();
-                if(window.cordova) {
-                    var cordovaMetadata = cordova.require("cordova/plugin_list").metadata;
-                    if(inAppBrowserInstalled(cordovaMetadata) === true) {
-                        var redirect_uri = "http://localhost/callback";
-                        if(options !== undefined) {
-                            if(options.hasOwnProperty("redirect_uri")) {
-                                redirect_uri = options.redirect_uri;
-                            }
-                        }
-
-                        if(typeof jsSHA !== "undefined") {
-                            var oauthObject = {
-                                oauth_consumer_key: clientId,
-                                oauth_nonce: $cordovaOauthUtility.createNonce(10),
-                                oauth_signature_method: "HMAC-SHA1",
-                                oauth_timestamp: Math.round((new Date()).getTime() / 1000.0),
-                                oauth_version: "1.0"
-                            };
-                            var signatureObj = $cordovaOauthUtility.createSignature("POST", "https://api.twitter.com/oauth/request_token", oauthObject,  { oauth_callback: redirect_uri }, clientSecret);
-                            $http({
-                                method: "post",
-                                url: "https://api.twitter.com/oauth/request_token",
-                                headers: {
-                                    "Authorization": signatureObj.authorization_header,
-                                    "Content-Type": "application/x-www-form-urlencoded"
-                                },
-                                data: "oauth_callback=" + encodeURIComponent(redirect_uri)
-                            })
-                                .success(function(requestTokenResult) {
-                                    var requestTokenParameters = (requestTokenResult).split("&");
-                                    var parameterMap = {};
-                                    for(var i = 0; i < requestTokenParameters.length; i++) {
-                                        parameterMap[requestTokenParameters[i].split("=")[0]] = requestTokenParameters[i].split("=")[1];
-                                    }
-                                    if(parameterMap.hasOwnProperty("oauth_token") === false) {
-                                        deferred.reject("Oauth request token was not received");
-                                    }
-                                    var browserRef = window.open('https://api.twitter.com/oauth/authenticate?oauth_token=' + parameterMap.oauth_token, '_blank', 'location=no,clearsessioncache=yes,clearcache=yes');
-                                    browserRef.addEventListener('loadstart', function(event) {
-                                        if((event.url).indexOf(redirect_uri) === 0) {
-                                            var callbackResponse = (event.url).split("?")[1];
-                                            var responseParameters = (callbackResponse).split("&");
-                                            var parameterMap = {};
-                                            for(var i = 0; i < responseParameters.length; i++) {
-                                                parameterMap[responseParameters[i].split("=")[0]] = responseParameters[i].split("=")[1];
-                                            }
-                                            if(parameterMap.hasOwnProperty("oauth_verifier") === false) {
-                                                deferred.reject("Browser authentication failed to complete.  No oauth_verifier was returned");
-                                            }
-                                            delete oauthObject.oauth_signature;
-                                            oauthObject.oauth_token = parameterMap.oauth_token;
-                                            var signatureObj = $cordovaOauthUtility.createSignature("POST", "https://api.twitter.com/oauth/access_token", oauthObject,  { oauth_verifier: parameterMap.oauth_verifier }, clientSecret);
-                                            $http({
-                                                method: "post",
-                                                url: "https://api.twitter.com/oauth/access_token",
-                                                headers: {
-                                                    "Authorization": signatureObj.authorization_header
-                                                },
-                                                params: {
-                                                    "oauth_verifier": parameterMap.oauth_verifier
-                                                }
-                                            })
-                                                .success(function(result) {
-                                                    var accessTokenParameters = result.split("&");
-                                                    var parameterMap = {};
-                                                    for(var i = 0; i < accessTokenParameters.length; i++) {
-                                                        parameterMap[accessTokenParameters[i].split("=")[0]] = accessTokenParameters[i].split("=")[1];
-                                                    }
-                                                    if(parameterMap.hasOwnProperty("oauth_token_secret") === false) {
-                                                        deferred.reject("Oauth access token was not received");
-                                                    }
-                                                    deferred.resolve(parameterMap);
-                                                })
-                                                .error(function(error) {
-                                                    deferred.reject(error);
-                                                })
-                                                .finally(function() {
-                                                    setTimeout(function() {
-                                                        browserRef.close();
-                                                    }, 10);
-                                                });
-                                        }
-                                    });
-                                    browserRef.addEventListener('exit', function(event) {
-                                        deferred.reject("The sign in flow was canceled");
-                                    });
-                                })
-                                .error(function(error) {
-                                    deferred.reject(error);
-                                });
-                        } else {
-                            deferred.reject("Missing jsSHA JavaScript library");
-                        }
-                    } else {
-                        deferred.reject("Could not find InAppBrowser plugin");
-                    }
-                } else {
-                    deferred.reject("Cannot authenticate via a web browser");
-                }
-                return deferred.promise;
+            twitter: function(clientId, appScope, options) {
+              return wrapWithChecks('facebook', arguments);
             },
 
             /*


### PR DESCRIPTION
This is a exploratory PR because if it were done fully it would result in a big change set, so better to check first.

My goal was to remove the duplication of the common error checks (does `cordova` exist and the in app browser); I've only applied my proposed idea to 3 so far: Twitter, Instagram & Facebook.

Essentially I've taken the core of the oauth calls and wrapped them [in an outer function](https://github.com/nraboy/ng-cordova-oauth/compare/nraboy:development...otupman:err-check-duplication-removal?expand=1#diff-b23fa922c0bc678a7dce73f4d54fd74dR226) that does the error checks.

Applying this across all the oauth methods would reduce each to a smaller core, which should allow more commonality to because more obvious and ripe for more refactoring (the interaction with the `browserRef` is a prime candidate...)