### PR TITLE
Do not clear cookies nor force permission dialog for Google login

### DIFF
--- a/src/oauth.js
+++ b/src/oauth.js
@@ -159,7 +159,7 @@ angular.module("oauth.providers", ["oauth.utils"])
                                 redirect_uri = options.redirect_uri;
                             }
                         }
-                        var browserRef = window.open('https://accounts.google.com/o/oauth2/auth?client_id=' + clientId + '&redirect_uri=' + redirect_uri + '&scope=' + appScope.join(" ") + '&approval_prompt=force&response_type=token', '_blank', 'location=no,clearsessioncache=yes,clearcache=yes');
+                        var browserRef = window.open('https://accounts.google.com/o/oauth2/auth?client_id=' + clientId + '&redirect_uri=' + redirect_uri + '&scope=' + appScope.join(" ") + '&approval_prompt=auto&response_type=token', '_blank', 'location=no,clearsessioncache=no,clearcache=no');
                         browserRef.addEventListener("loadstart", function(event) {
                             if((event.url).indexOf(redirect_uri) === 0) {
                            		browserRef.removeEventListener("exit",function(event){});


### PR DESCRIPTION
Right now, the user is asked to login each time (having to input e-mail and password) a call to `$cordovaOauth.google` is done, instead of remembering that we already logged in. 

On top of that, forcing the permissions dialog with `approval_prompt=force` makes the user have to approve the permissions each time, even if she already gave permissions before.

Changing these parameters allow for the user to have to log in only once in the app, and in subsequent app launches / calls to `$cordovaOauth.google` there will be only a brief blink of InAppBrowser opening and closing immediately because there is no more need of inputting user and password and giving permissions to get the access token.

The blinking could be prevented by opening InAppBrowser with hidden=true and see if we get the access token. If we don't, then reopen with hidden=false so the user can log in. Might add this in a future PR.

Only tested with Google login as it's the only one I need for now, but I suppose this might be an issue with other providers as well.
