### PR TITLE
fixing the linkedin auth code parsing

### DIFF
--- a/src/oauth.js
+++ b/src/oauth.js
@@ -330,7 +330,7 @@ angular.module("oauth.providers", ["oauth.utils"])
 
                         browserRef.addEventListener('loadstart', function(event) {
                             if((event.url).indexOf(redirect_uri) === 0) {
-                                requestToken = (event.url).split("code=")[1];
+                                requestToken = (event.url).split("code=")[1].split("&")[0];
                                 $http.defaults.headers.post['Content-Type'] = 'application/x-www-form-urlencoded';
                                 $http({method: "post", url: "https://www.linkedin.com/uas/oauth2/accessToken", data: "client_id=" + clientId + "&client_secret=" + clientSecret + "&redirect_uri=" + redirect_uri + "&grant_type=authorization_code" + "&code=" + requestToken })
                                     .success(function(data) {


### PR DESCRIPTION
Currently the _state_ param was not being segregated from the _auth code_.