### PR TITLE
Fix for Cordova 6.0.0 isInAppBrowser() function returning false

### DIFF
--- a/src/utility.js
+++ b/src/utility.js
@@ -19,12 +19,12 @@ function cordovaOauthUtility($q) {
    */
   function isInAppBrowserInstalled() {
     var cordovaPluginList = cordova.require("cordova/plugin_list");
-    var inAppBrowserNames = ["cordova-plugin-inappbrowser", "org.apache.cordova.inappbrowser"];
+    var inAppBrowserNames = ["cordova-plugin-inappbrowser", "cordova-plugin-inappbrowser.inappbrowser", "org.apache.cordova.inappbrowser"];
 
     if (Object.keys(cordovaPluginList.metadata).length === 0) {
       var formatedPluginList = cordovaPluginList.map(
         function(plugin) {
-          return plugin.pluginId;
+          return plugin.id || plugin.pluginId;
         });
 
       return inAppBrowserNames.some(function(name) {


### PR DESCRIPTION
Sorry, I just realised I made the changes to the `dist/` file instead of `utility.js` :/

I also noted that the plugin name seems to have changed to `cordova-plugin-inappbrowser.inappbrowser`, I added a case for this

I've corrected this...