### PR TITLE
adding id_token to google authentication response

### DIFF
--- a/dist/ng-cordova-oauth.js
+++ b/dist/ng-cordova-oauth.js
@@ -689,7 +689,7 @@ function google($q, $http, $cordovaOauthUtility) {
             redirect_uri = options.redirect_uri;
           }
         }
-        var browserRef = window.cordova.InAppBrowser.open('https://accounts.google.com/o/oauth2/auth?client_id=' + clientId + '&redirect_uri=' + redirect_uri + '&scope=' + appScope.join(" ") + '&approval_prompt=force&response_type=token', '_blank', 'location=no,clearsessioncache=yes,clearcache=yes');
+        var browserRef = window.cordova.InAppBrowser.open('https://accounts.google.com/o/oauth2/auth?client_id=' + clientId + '&redirect_uri=' + redirect_uri + '&scope=' + appScope.join(" ") + '&approval_prompt=force&response_type=token id_token', '_blank', 'location=no,clearsessioncache=yes,clearcache=yes');
         browserRef.addEventListener("loadstart", function(event) {
           if((event.url).indexOf(redirect_uri) === 0) {
             browserRef.removeEventListener("exit",function(event){});
@@ -701,7 +701,7 @@ function google($q, $http, $cordovaOauthUtility) {
               parameterMap[responseParameters[i].split("=")[0]] = responseParameters[i].split("=")[1];
             }
             if(parameterMap.access_token !== undefined && parameterMap.access_token !== null) {
-              deferred.resolve({ access_token: parameterMap.access_token, token_type: parameterMap.token_type, expires_in: parameterMap.expires_in });
+              deferred.resolve({ access_token: parameterMap.access_token, token_type: parameterMap.token_type, expires_in: parameterMap.expires_in, id_token: parameterMap.id_token });
             } else {
               deferred.reject("Problem authenticating");
             }

--- a/src/oauth.google.js
+++ b/src/oauth.google.js
@@ -22,7 +22,7 @@ function google($q, $http, $cordovaOauthUtility) {
             redirect_uri = options.redirect_uri;
           }
         }
-        var browserRef = window.cordova.InAppBrowser.open('https://accounts.google.com/o/oauth2/auth?client_id=' + clientId + '&redirect_uri=' + redirect_uri + '&scope=' + appScope.join(" ") + '&approval_prompt=force&response_type=token', '_blank', 'location=no,clearsessioncache=yes,clearcache=yes');
+        var browserRef = window.cordova.InAppBrowser.open('https://accounts.google.com/o/oauth2/auth?client_id=' + clientId + '&redirect_uri=' + redirect_uri + '&scope=' + appScope.join(" ") + '&approval_prompt=force&response_type=token id_token', '_blank', 'location=no,clearsessioncache=yes,clearcache=yes');
         browserRef.addEventListener("loadstart", function(event) {
           if((event.url).indexOf(redirect_uri) === 0) {
             browserRef.removeEventListener("exit",function(event){});
@@ -34,7 +34,7 @@ function google($q, $http, $cordovaOauthUtility) {
               parameterMap[responseParameters[i].split("=")[0]] = responseParameters[i].split("=")[1];
             }
             if(parameterMap.access_token !== undefined && parameterMap.access_token !== null) {
-              deferred.resolve({ access_token: parameterMap.access_token, token_type: parameterMap.token_type, expires_in: parameterMap.expires_in });
+              deferred.resolve({ access_token: parameterMap.access_token, token_type: parameterMap.token_type, expires_in: parameterMap.expires_in, id_token: parameterMap.id_token });
             } else {
               deferred.reject("Problem authenticating");
             }


### PR DESCRIPTION
Not sure what happened, but this functionality was removed during large refactoring in fc16e48ec3cae5dd68c7cc869be8e2a0cfbac594. So, getting it back.

A commit where it was added:
https://github.com/nraboy/ng-cordova-oauth/commit/f589580c5b3d63c06dbfd269758b40c1c907432f#diff-3a1276f4dc4422026a36b4b8750287bf

A commit where it was removed:
https://github.com/nraboy/ng-cordova-oauth/commit/fc16e48ec3cae5dd68c7cc869be8e2a0cfbac594#diff-3a1276f4dc4422026a36b4b8750287bf