### PR TITLE
Do not change default http header

### DIFF
--- a/src/oauth.linkedin.js
+++ b/src/oauth.linkedin.js
@@ -29,8 +29,7 @@ function linkedin($q, $http, $cordovaOauthUtility) {
         browserRef.addEventListener('loadstart', function(event) {
           if((event.url).indexOf(redirect_uri) === 0) {
             requestToken = (event.url).split("code=")[1].split("&")[0];
-            $http.defaults.headers.post['Content-Type'] = 'application/x-www-form-urlencoded';
-            $http({method: "post", url: "https://www.linkedin.com/uas/oauth2/accessToken", data: "client_id=" + clientId + "&client_secret=" + clientSecret + "&redirect_uri=" + redirect_uri + "&grant_type=authorization_code" + "&code=" + requestToken })
+            $http({method: "post", headers: {'Content-Type': 'application/x-www-form-urlencoded'}, url: "https://www.linkedin.com/uas/oauth2/accessToken", data: "client_id=" + clientId + "&client_secret=" + clientSecret + "&redirect_uri=" + redirect_uri + "&grant_type=authorization_code" + "&code=" + requestToken })
               .success(function(data) {
                 deferred.resolve(data);
               })


### PR DESCRIPTION
Instead of changing global $http behavior, I chose to set header type within the $http call.
I found this because the change in global behavior has broken the rest of my application code which relied on another encoding type ('json...')
As there is only one call, I don't see why the global behavior should be changed.  Maybe the 'deferred.resolve(data)' needs a global setup ?