### PR TITLE
Defining main in bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,6 +21,7 @@
     "ionic framework"
   ],
   "license": "MIT",
+  "main" : "dist/ng-cordova-oauth.js",
   "ignore": [
     "**/.*",
     "node_modules",

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "ng-cordova-oauth",
-  "main": ["dist/ng-cordova-oauth.js", "dist/ng-cordova-oauth.min.js"],
+  "main": "dist/ng-cordova-oauth.js",
   "version": "0.2.5",
   "homepage": "https://github.com/nraboy/ng-cordova-oauth",
   "authors": [
@@ -21,7 +21,6 @@
     "ionic framework"
   ],
   "license": "MIT",
-  "main" : "dist/ng-cordova-oauth.js",
   "ignore": [
     "**/.*",
     "node_modules",


### PR DESCRIPTION
If the bower file does not contain a main property than some dependency utils like wiredep will include all files under ./dist