### PR TITLE
Adding var to requestToken so uglify:build take it as a variable

### DIFF
--- a/src/oauth.linkedin.js
+++ b/src/oauth.linkedin.js
@@ -27,12 +27,11 @@
               redirect_uri = options.redirect_uri;
             }
           }
-
           var browserRef = window.cordova.InAppBrowser.open('https://www.linkedin.com/uas/oauth2/authorization?client_id=' + clientId + '&redirect_uri=' + redirect_uri + '&scope=' + appScope.join(" ") + '&response_type=code&state=' + state, '_blank', 'location=no,clearsessioncache=yes,clearcache=yes');
           browserRef.addEventListener('loadstart', function(event) {
             if((event.url).indexOf(redirect_uri) === 0) {
               try {
-                requestToken = (event.url).split("code=")[1].split("&")[0];
+                var requestToken = (event.url).split("code=")[1].split("&")[0];
                 $http({method: "post", headers: {'Content-Type': 'application/x-www-form-urlencoded'}, url: "https://www.linkedin.com/uas/oauth2/accessToken", data: "client_id=" + clientId + "&client_secret=" + clientSecret + "&redirect_uri=" + redirect_uri + "&grant_type=authorization_code" + "&code=" + requestToken })
                   .success(function(data) {
                     deferred.resolve(data);


### PR DESCRIPTION
There is a problem with linkedin when trying to get request token when the code is uglified, because the uglifier doesn't get requestToken as a variable. This fix the problem making requestToken a variable explicitly. I tested this code building it with grunt default task and attaching only the *.min.js file , in an iOS emulator.